### PR TITLE
Configure CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+bundler_args: --without debug
+script: "bundle exec rake ci"
+sudo: false
+cache: bundler
+rvm:
+ - 2.3.3

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,9 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+
+desc 'Run CI'
+task :ci do
+  sh 'cp config/ldf.yml.sample_repository config/ldf.yml'
+  Rake::Task['spec'].invoke
+end


### PR DESCRIPTION
CI was using a default configuration, which led to broken builds due to dependency problems. This adds a base configuration which we can tweak as support is better defined.