### PR TITLE
Add a Backend factory method

### DIFF
--- a/app/controllers/subject_controller.rb
+++ b/app/controllers/subject_controller.rb
@@ -6,18 +6,11 @@ class SubjectController < ApplicationController
   end
 
   def self.assign_cache_service
-    case Setting.cache_backend
-      when 'marmotta'
-        @cache = LinkedDataFragments::Marmotta.new
-      when 'repository'
-        @cache = LinkedDataFragments::Repository.new
-      when 'blazegraph'
-        @cache = LinkedDataFragments::Blazegraph.new
-      else
-        #FIXME: What type of error should this be? Need to unit test this as well once figured out.
-        raise ArgumentError, 'Invalid cache_backend set in the yml config'
-    end
-    return @cache
+    @cache = LinkedDataFragments::BackendBase
+               .for(name: Setting.cache_backend)
+  rescue ArgumentErrror
+    raise ArgumentError, 'Invalid cache_backend set in the yml config'
+        
   end
 
   def subject

--- a/lib/linked_data_fragments/backend_base.rb
+++ b/lib/linked_data_fragments/backend_base.rb
@@ -9,6 +9,26 @@ module LinkedDataFragments
   #   resources from the cache.
   class BackendBase
     ##
+    # A backend factory.
+    #
+    # @param name [#to_sym]
+    # @return [BackendBase] a backend instance
+    #
+    # @raise [ArgumentError] when the name does not match a repository
+    def self.for(name: :repository)
+      case name.to_sym
+      when :marmotta
+        LinkedDataFragments::Marmotta.new
+      when :repository
+        LinkedDataFragments::Repository.new
+      when :blazegraph
+        LinkedDataFragments::Blazegraph.new
+      else
+        raise ArgumentError, "Invalid backend `#{name}` specified."
+      end
+    end
+
+    ##
     # @!attribute [rw] cache_backend_url
     #   @return [String, nil] a target url in string form; `nil` may be 
     #     returned when the backend repository is not remote.

--- a/spec/support/shared_examples/backend.rb
+++ b/spec/support/shared_examples/backend.rb
@@ -2,6 +2,18 @@ shared_examples 'a backend' do
   let(:url) { 'http://dbpedia.org/resource/Berlin' }
 
   after { subject.delete_all! }
+  
+  describe '.for' do
+    it 'defaults to Repostiory' do
+      expect(described_class.for)
+        .to be_a LinkedDataFragments::Repository
+    end
+
+    it 'raises ArgumentError when name does not exist' do
+      expect { described_class.for(name: :totally_fake) }
+        .to raise_error ArgumentError
+    end
+  end
 
   describe '#add', :vcr do
     it 'adds a url' do


### PR DESCRIPTION
Some logic for constructing cache backends was hanging around in a controller, this moves it to a factory method on the `BackendBase` class. Use `BackendBase.for` going forward.