### PR TITLE
Move cache creation out of the controllers

### DIFF
--- a/app/controllers/subject_controller.rb
+++ b/app/controllers/subject_controller.rb
@@ -2,37 +2,32 @@ class SubjectController < ApplicationController
   before_action :fix_passed_params
 
   def self.cache_service
-    @cache || assign_cache_service
-  end
-
-  def self.assign_cache_service
-    @cache = LinkedDataFragments::BackendBase
-               .for(name: Setting.cache_backend)
-  rescue ArgumentErrror
-    raise ArgumentError, 'Invalid cache_backend set in the yml config'
-        
+    LinkedDataFragments::Service.instance.cache
   end
 
   def subject
-    @data = SubjectController.cache_service.retrieve(params[:subject])
+    data = self.class.cache_service.retrieve(params[:subject])
 
     respond_to do |f|
       renderer_mapping.each do |format, renderer|
         f.send(format) do
-          render :text => renderer.call(@data)
+          render :text => renderer.call(data)
         end
       end
     end
-
   end
 
+  private
+
+  # Seems like a double '//' in the captured param is changed to a single one. 
+  # Unsure of how better to do this...
   def fix_passed_params
-    #Seems like a double '//' in the captured param is changed to a single one. Unsure of how better to do this...
     single_slash_match = params[:subject].match(/^http[s]*\:\/(?!\/)/)
+
     if single_slash_match.present?
-      params[:subject] = params[:subject][0..single_slash_match[0].length-1] + '/' + params[:subject][single_slash_match[0].length..params[:subject].length]
+      params[:subject] = 
+        params[:subject][0..single_slash_match[0].length-1] + '/' +
+        params[:subject][single_slash_match[0].length..params[:subject].length]
     end
   end
-
-
 end

--- a/lib/linked_data_fragments/backend_base.rb
+++ b/lib/linked_data_fragments/backend_base.rb
@@ -14,7 +14,7 @@ module LinkedDataFragments
     # @param name [#to_sym]
     # @return [BackendBase] a backend instance
     #
-    # @raise [ArgumentError] when the name does not match a repository
+    # @raise [UnsupportedBackend] when the name does not match a repository
     def self.for(name: :repository)
       case name.to_sym
       when :marmotta
@@ -24,7 +24,7 @@ module LinkedDataFragments
       when :blazegraph
         LinkedDataFragments::Blazegraph.new
       else
-        raise ArgumentError, "Invalid backend `#{name}` specified."
+        raise UnsupportedBackend, "Invalid backend `#{name}` specified."
       end
     end
 
@@ -128,5 +128,7 @@ module LinkedDataFragments
       raise NotImplementedError,
             "#{self.class} should implement `#retrieve!`, but does not."
     end
+
+    class UnsupportedBackend < NameError; end
   end
 end

--- a/lib/linked_data_fragments/service.rb
+++ b/lib/linked_data_fragments/service.rb
@@ -1,0 +1,14 @@
+module LinkedDataFragments
+  ##
+  # The cache
+  class Service
+    include Singleton
+
+    ##
+    # @return [BackendBase]
+    def cache
+      @cache ||= 
+        LinkedDataFragments::BackendBase.for(name: Settings.cache_backend)
+    end
+  end
+end

--- a/lib/linked_data_fragments/service.rb
+++ b/lib/linked_data_fragments/service.rb
@@ -6,9 +6,12 @@ module LinkedDataFragments
 
     ##
     # @return [BackendBase]
+    # @raise [BackendBase::UnsupportedBackend] when the configured repository is
+    #   not supported
     def cache
-      @cache ||= 
-        LinkedDataFragments::BackendBase.for(name: Settings.cache_backend)
+      @cache ||= BackendBase.for(name: Settings.cache_backend)
+    rescue BackendBase::UnsupportedBackend
+      raise BackendBase::UnsupportedBackend, 'Invalid cache_backend set in the yml config'
     end
   end
 end

--- a/spec/linked_data_fragments/service_spec.rb
+++ b/spec/linked_data_fragments/service_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+require 'linked_data_fragments/service'
+require 'linked_data_fragments/repository'
+
+describe LinkedDataFragments::Service do
+  subject { described_class.instance }
+  
+  before do
+    # @todo: REMOVE THIS HACKY STUB
+    allow(LinkedDataFragments::Settings)
+      .to receive(:cache_backend)
+      .and_return(:repository)
+  end
+
+  describe '#cache' do
+    it 'gives a backend' do
+      expect(subject.cache).to respond_to :retrieve
+    end
+  end
+end

--- a/spec/support/shared_examples/backend.rb
+++ b/spec/support/shared_examples/backend.rb
@@ -11,7 +11,7 @@ shared_examples 'a backend' do
 
     it 'raises ArgumentError when name does not exist' do
       expect { described_class.for(name: :totally_fake) }
-        .to raise_error ArgumentError
+        .to raise_error LinkedDataFragments::BackendBase::UnsupportedBackend
     end
   end
 


### PR DESCRIPTION
Previously, the `SubjectController` handled initializing and holding onto the cache backend instance. This is not really a controller job.

f973658 reimplements this behavior in a centralized `Service` singleton, which maintains the cache on an application wide basis. The idea here is to centralize this responsibility, and guarantee that there is only one canonical cache backend at any given time.

644555a moves the existing controller to use the singleton, and cleans up the error handling.