### PR TITLE
Update RDF::VOID

### DIFF
--- a/lib/linked_data_fragments/schemas/dataset_schema.rb
+++ b/lib/linked_data_fragments/schemas/dataset_schema.rb
@@ -2,8 +2,8 @@ module LinkedDataFragments
   ##
   # A schema for `hydracore:Collection`/`Dataset` nodes.
   class DatasetSchema < ActiveTriples::Schema
-    property :subset,              predicate: RDF::VOID.subset
-    property :uri_lookup_endpoint, predicate: RDF::VOID.uriLookupEndpoint
+    property :subset,              predicate: RDF::Vocab::VOID.subset
+    property :uri_lookup_endpoint, predicate: RDF::Vocab::VOID.uriLookupEndpoint
 
     # Change search so that it points to a search node.
     property :search, predicate: RDF::URI.intern("http://www.w3.org/ns/hydra/core#search")

--- a/lib/linked_data_fragments/schemas/result_schema.rb
+++ b/lib/linked_data_fragments/schemas/result_schema.rb
@@ -2,7 +2,7 @@ module LinkedDataFragments
   ##
   # Schema for Result model
   class ResultSchema < ActiveTriples::Schema
-    property :subset,      :predicate => RDF::VOID.subset
+    property :subset,      :predicate => RDF::Vocab::VOID.subset
 
     # Descriptive
     property :title,       :predicate => RDF::Vocab::DC.title


### PR DESCRIPTION
VOID has been moved to the `RDF::Vocab` repository. The alias in `RDF` remains in 1.99.x, but is removed in RDF.rb 2.0. Since other vocabularies have already been updated, it seemed appropriate to bring this one up to date, too.