### PR TITLE
Add an error message for missing/invalid config

### DIFF
--- a/lib/linked_data_fragments/settings.rb
+++ b/lib/linked_data_fragments/settings.rb
@@ -18,7 +18,8 @@ module LinkedDataFragments
       # @return [Hash<String, String>] the settings from the YAML config
       #   at {.config_path}.
       def config
-        @config ||= YAML::load(File.open(config_path))[env]
+        @config ||= YAML::load(File.open(config_path))
+          .fetch(env) { raise "#{env} missing from ldf.yml" }
           .with_indifferent_access
       end
 


### PR DESCRIPTION
Certain configuration errors (mainly, a missing env key) in the YAML config would cause `NoMethodError` on `nil`. This is slightly nicer.